### PR TITLE
docs(help): fix the typo of option description

### DIFF
--- a/main.py
+++ b/main.py
@@ -35,8 +35,8 @@ from src.player.BuildAndRunBot import *
 PARAMETERS_ERROR_RETURN_CODE = 1
 
 def printUsage():
-    print("Usage: python quoridor.py [{-h|--help}] {-p|--players=}<PlayerName:PlayerType,...> [{-r|--rounds=}<roundCount>] [{-x|--cols=}<ColCount>] [{-y|--rows=}<RowCount>] [{-f|--fences=}<TotalFenceCount>] [{s|--square_size=}<SquareSizeInPixels>]")
-    print("Example: python quoridor.py --players=Alain:Human,Benoit:BuilderBot,Caroline:RandomBot,Daniel:RunnerBot --square-size=32")
+    print("Usage: python main.py [{-h|--help}] {-p|--players=}<PlayerName:PlayerType,...> [{-r|--rounds=}<roundCount>] [{-x|--cols=}<ColCount>] [{-y|--rows=}<RowCount>] [{-f|--fences=}<TotalFenceCount>] [{-s|--square_size=}<SquareSizeInPixels>]")
+    print("Example: python main.py --players=Alain:Human,Benoit:BuilderBot,Caroline:RandomBot,Daniel:RunnerBot --square_size=32")
 
 def readArguments():
     try:


### PR DESCRIPTION
Some description of the options are obviously typo. Fix them to make first-time users launch this application easier.

**Steps to Test This Pull Request**
`python main.py --players=Alain:Human,Benoit:Human --fences=20 --square_size=64`

